### PR TITLE
Install .NET 7 Desktop Runtime for Rhino 8 and 9

### DIFF
--- a/install-rhino
+++ b/install-rhino
@@ -97,6 +97,9 @@ run winetricks-vcrun "$TOOLS_CACHE/winetricks" -q vcrun2005 vcrun2010 vcrun2013 
 # FIXME: Installing dotnet sometimes hangs with RtlpWaitForCriticalSection on ntdll
 run winetricks-dotnet48 "$TOOLS_CACHE/winetricks" -q dotnet48
 run winetricks-win11 "$TOOLS_CACHE/winetricks" -q win11
+if [[ $MAJOR_VERSION = 8 || $MAJOR_VERSION = wip ]]; then
+  run winetricks-dotnetdesktop7 "$TOOLS_CACHE/winetricks" -q dotnetdesktop7
+fi
 
 RHINO_INSTALLER_DIR="$SCRIPT_DIR/build/rhino-installer/${RHINO_INSTALLER%%.exe}"
 run cabextract cabextract -d "$RHINO_INSTALLER_DIR" "$TOOLS_CACHE/$RHINO_INSTALLER"


### PR DESCRIPTION
Install .NET 7 Desktop Runtime for Rhino 8 and 9. This is required, but Rhino 8 still crashes on startup.