### PR TITLE
Test Rhino startup for 30s

### DIFF
--- a/ci/test-rhino
+++ b/ci/test-rhino
@@ -6,7 +6,7 @@ cd "$SCRIPT_DIR/.."
 
 ./run-rhino "$@" &
 pid=$!
-sleep 10
+sleep 30
 
 # Check if $pid is still alive
 if kill -0 $pid 2>/dev/null; then


### PR DESCRIPTION
10s does not seem to be enough to see a crash on Rhino 8.